### PR TITLE
Prevented text alerts from being drawn off screen

### DIFF
--- a/src/ui/textAlertDrawTool.py
+++ b/src/ui/textAlertDrawTool.py
@@ -1,14 +1,36 @@
 # This class is responsible for drawing text alerts on the screen.
 
-class TextAlertDrawTool():
+from lib.graphiklib.graphik import Graphik
 
-    def drawTextAlert(self, textAlert, graphik):
-        numLines = len(textAlert.text)        
-        backgroundColor = (255, 255, 255)
+
+class TextAlertDrawTool():
+    def __init__(self):
+        self.backgroundColor = (255, 255, 255)
+        self.backgroundWidth = 250
+
+    def drawTextAlert(self, textAlert, graphik: Graphik):
+        numLines = len(textAlert.text)
+        
+        # prepare background
+        backgroundHeight = self.prepareBackground(textAlert, graphik, numLines)
+        
+        # ensure text will not be drawn outside of the screen
+        if textAlert.y + backgroundHeight > graphik.gameDisplay.get_height():
+            textAlert.y = graphik.gameDisplay.get_height() - 20*numLines - 20
+        if textAlert.x + self.backgroundWidth > graphik.gameDisplay.get_width():
+            textAlert.x = graphik.gameDisplay.get_width() - 250
+        if textAlert.y < 0:
+            textAlert.y = 0
+        if textAlert.x < textAlert.size * 6:
+            textAlert.x = textAlert.size * 6
+        
+        # draw text
+        for i in range(0, len(textAlert.text)):
+            graphik.drawText(textAlert.text[i], textAlert.x, textAlert.y + 20*i, textAlert.size, textAlert.color)
+    
+    def prepareBackground(self, textAlert, graphik: Graphik, numLines):
         backgroundX = textAlert.x - textAlert.size * 6
         backgroundY = textAlert.y - textAlert.size
-        backgroundWidth = 250
         backgroundHeight = 20*numLines + 20
-        graphik.drawRectangle(backgroundX, backgroundY, backgroundWidth, backgroundHeight, backgroundColor)
-        for i in range(0, numLines):
-            graphik.drawText(textAlert.text[i], textAlert.x, textAlert.y + 20*i, textAlert.size, textAlert.color)
+        graphik.drawRectangle(backgroundX, backgroundY, self.backgroundWidth, backgroundHeight, self.backgroundColor)
+        return backgroundHeight


### PR DESCRIPTION
## Problem
Sometimes text alerts cannot be read because some or all of them are off-screen.

## Solution
The TextAlertDrawTool has been modified to move the target position for text alerts if they will be drawn off screen.