### PR TITLE
Implemented berry cap

### DIFF
--- a/src/simulation/simulation.py
+++ b/src/simulation/simulation.py
@@ -184,10 +184,12 @@ class Simulation:
             grid = self.environment.getGrid()
             location = grid.getLocation(locationID)
             
-            berries = Berries()
-            location.addEntity(berries)
-            self.addEntity(berries)
-            berryBush.energy -= 1
+            # if location does not have more than 10 berries, add a berry
+            if len(location.getEntitiesOfType(Berries)) < 10:
+                berries = Berries()
+                location.addEntity(berries)
+                self.addEntity(berries)
+                berryBush.energy -= 1
             
     def initiateEntityActions(self):
         for entityId in self.livingEntityIds:


### PR DESCRIPTION
This PR addresses the issue of berry bushes producing an unlimited number of berries, which has led to an imbalance in the game. Berry bushes currently have no restrictions on berry growth, causing them to become overpowered and disrupt the food chain by providing an excessive amount of food.