### PR TITLE
Setup Screen

### DIFF
--- a/src/apex.py
+++ b/src/apex.py
@@ -2,6 +2,7 @@ import pygame
 from lib.graphiklib.graphik import Graphik
 from screen.mainMenuScreen import MainMenuScreen
 from screen.screenType import ScreenType
+from screen.setupScreen import SetupScreen
 from screen.simulationScreen import SimulationScreen
 from simulation.config import Config
 
@@ -18,6 +19,7 @@ class Apex:
         self.debug = False
         self.mainMenuScreen = MainMenuScreen(self.graphik)
         self.simulationScreen = SimulationScreen(self.graphik, self.config)
+        self.setupScreen = SetupScreen(self.graphik, self.config)
         self.currentScreen = self.mainMenuScreen
 
     # public methods ---------------------------------------------------------
@@ -26,8 +28,12 @@ class Apex:
         while True:
             result = self.currentScreen.run()
             if result == ScreenType.MAIN_MENU_SCREEN:
-                return "restart"
+                self.currentScreen = self.mainMenuScreen
+            elif result == ScreenType.SETUP_SCREEN:
+                self.currentScreen = self.setupScreen
             elif result == ScreenType.SIMULATION_SCREEN:
+                self.config.calculateValues()
+                self.simulationScreen.initializeSimulation()
                 self.currentScreen = self.simulationScreen
             elif result == ScreenType.NONE:
                 self.__quitApplication()
@@ -44,7 +50,6 @@ class Apex:
 
     # Shuts down the application.
     def __quitApplication(self):
-        self.simulationScreen.simulation.cleanup()
         pygame.quit()
         quit()
 

--- a/src/screen/mainMenuScreen.py
+++ b/src/screen/mainMenuScreen.py
@@ -10,11 +10,11 @@ class MainMenuScreen:
     def __init__(self, graphik: Graphik):
         self.graphik = graphik
         self.running = True
-        self.nextScreen = ScreenType.SIMULATION_SCREEN
+        self.nextScreen = ScreenType.SETUP_SCREEN
         self.changeScreen = False
 
-    def switchToSimulationScreen(self):
-        self.nextScreen = ScreenType.SIMULATION_SCREEN
+    def switchToSetupScreen(self):
+        self.nextScreen = ScreenType.SETUP_SCREEN
         self.changeScreen = True
 
     def quitApplication(self):
@@ -48,7 +48,7 @@ class MainMenuScreen:
             (0, 0, 0),
             30,
             "create new simulation",
-            self.switchToSimulationScreen,
+            self.switchToSetupScreen,
         )
         ypos = ypos + height + margin
         self.graphik.drawButton(
@@ -78,7 +78,7 @@ class MainMenuScreen:
                 )
 
     def handleKeyDownEvent(self, key):
-        self.switchToSimulationScreen()
+        self.switchToSetupScreen()
 
     def run(self):
         while not self.changeScreen:

--- a/src/screen/setupScreen.py
+++ b/src/screen/setupScreen.py
@@ -1,0 +1,163 @@
+import os
+import pygame
+
+from lib.graphiklib.graphik import Graphik
+from screen.screenType import ScreenType
+from simulation.config import Config
+
+# @author Daniel McCoy Stephenson
+class SetupScreen:
+    # constructors -----------------------------------------------------------
+    def __init__(self, graphik: Graphik, config: Config):
+        self.graphik = graphik
+        self.config = config
+        self.running = True
+        self.nextScreen = ScreenType.SIMULATION_SCREEN
+        self.changeScreen = False
+
+    def switchToSimulationScreen(self):
+        self.nextScreen = ScreenType.SIMULATION_SCREEN
+        self.changeScreen = True
+    
+    def switchToMainMenuScreen(self):
+        self.nextScreen = ScreenType.MAIN_MENU_SCREEN
+        self.changeScreen = True
+
+    def quitApplication(self):
+        pygame.quit()
+        quit()
+
+    def drawText(self):
+        x, y = self.graphik.getGameDisplay().get_size()
+        xpos = x / 2
+        ypos = y / 10
+        self.graphik.drawText("Setup", xpos, ypos, 64, (255, 255, 255))
+
+    def drawMenuButtons(self):
+        x, y = self.graphik.getGameDisplay().get_size()
+        width = x / 5
+        height = y / 10
+        
+        # draw button in top left to return to main menu
+        xpos = x / 10
+        ypos = y / 10
+        margin = 10
+        backgroundColor = (255, 255, 255)
+        self.graphik.drawButton(
+            xpos,
+            ypos,
+            width,
+            height,
+            backgroundColor,
+            (0, 0, 0),
+            30,
+            "main menu",
+            self.switchToMainMenuScreen,
+        )
+        
+        # draw button at bottom center to start simulation
+        xpos = x / 2 - width / 2
+        ypos = y - height - y / 10
+        self.graphik.drawButton(
+            xpos,
+            ypos,
+            width,
+            height,
+            backgroundColor,
+            (0, 0, 0),
+            30,
+            "start simulation",
+            self.switchToSimulationScreen,
+        )
+    
+        self.drawIntegerConfigOptionSetter(x, y, "gridSize", self.config.gridSize, self.decreaseGridSize, self.increaseGridSize)
+        
+        self.drawIntegerConfigOptionSetter(x, y - 100, "grassFactor", self.config.grassFactor, self.decreaseGrassFactor, self.increaseGrassFactor)
+    
+    def drawIntegerConfigOptionSetter(self, x, y, configOptionName, configOptionValue, decreaseFunction, increaseFunction):
+        # given x and y, draw text and buttons next to the text
+        textSize = 30
+        self.graphik.drawText(configOptionName + ": " + str(configOptionValue), x / 2, y / 2, textSize, (255, 255, 255))
+        
+        width = textSize
+        height = textSize
+        margin = 10
+        backgroundColor = (255, 255, 255)
+        
+        # draw buttons to decrease and increase grid size
+        xpos = x / 2 - width - margin
+        ypos = y / 2 + margin
+        self.graphik.drawButton(
+            xpos,
+            ypos,
+            width,
+            height,
+            backgroundColor,
+            (0, 0, 0),
+            30,
+            "-",
+            decreaseFunction,
+        )
+        
+        xpos = x / 2 + margin
+        self.graphik.drawButton(
+            xpos,
+            ypos,
+            width,
+            height,
+            backgroundColor,
+            (0, 0, 0),
+            30,
+            "+",
+            increaseFunction,
+        )
+        
+    def decreaseGridSize(self):
+        self.config.gridSize -= 1
+        if self.config.gridSize < 16:
+            self.config.gridSize = 16
+            
+    def increaseGridSize(self):
+        self.config.gridSize += 1
+        if self.config.gridSize > 64:
+            self.config.gridSize = 64
+    
+    def decreaseGrassFactor(self):
+        self.config.grassFactor -= 1
+        if self.config.grassFactor < 1:
+            self.config.grassFactor = 1
+            
+    def increaseGrassFactor(self):
+        self.config.grassFactor += 1
+        if self.config.grassFactor > 10:
+            self.config.grassFactor = 10
+
+    def drawVersion(self):
+        if os.path.isfile("version.txt"):
+            with open("version.txt", "r") as file:
+                version = file.read()
+
+                # display centered at bottom of screen
+                self.graphik.drawText(
+                    version,
+                    self.graphik.getGameDisplay().get_size()[0] / 2,
+                    self.graphik.getGameDisplay().get_size()[1] - 10,
+                    16,
+                    (255, 255, 255),
+                )
+
+    def run(self):
+        while not self.changeScreen:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    self.nextScreen = ScreenType.NONE
+                    self.changeScreen = True
+                    break
+
+            self.graphik.getGameDisplay().fill((0, 0, 0))
+            self.drawText()
+            self.drawMenuButtons()
+            self.drawVersion()
+            pygame.display.update()
+        self.changeScreen = False
+        return self.nextScreen

--- a/src/screen/simulationScreen.py
+++ b/src/screen/simulationScreen.py
@@ -26,7 +26,6 @@ class SimulationScreen:
         self.__nextScreen = ScreenType.NONE
         self.__changeScreen = False
         self.__paused = False
-        self.__initializeSimulation()
         self.__debug = False
         self.__textAlerts = []
         self.__textAlertFactory = TextAlertFactory()
@@ -86,14 +85,21 @@ class SimulationScreen:
             if (self.__config.endSimulationUponAllLivingEntitiesDying):
                 if self.simulation.getNumLivingEntities() == 0:
                     time.sleep(1)
-                    if (self.__config.autoRestart):
-                        self.__restartSimulation()
+                    self.simulation.cleanup()
+                    if self.__config.randomizeGridSizeUponRestart:
+                        self.__config.randomizeGridSize()
+                        self.__config.randomizeGrassGrowTime()
+                        self.__config.calculateValues()
+                    self.__nextScreen = ScreenType.SETUP_SCREEN
+                    self.__changeScreen = True
+                    if self.__paused:
+                        self.__paused = False
+
         
         self.__changeScreen = False
         return self.__nextScreen
-
-    # private methods --------------------------------------------------------
-    def __initializeSimulation(self):
+    
+    def initializeSimulation(self):
         name = "Simulation"
         self.simulation = Simulation(name, self.__config, self.__graphik.gameDisplay)
         self.simulation.generateInitialEntities()
@@ -101,6 +107,7 @@ class SimulationScreen:
         self.simulation.environment.printInfo()
         self.__initializeCaption()
 
+    # private methods --------------------------------------------------------
     def __initializeCaption(self):
         caption = "Apex - " + self.simulation.name + " - " + str(self.simulation.environment.getGrid().getColumns()) + "x" + str(self.simulation.environment.getGrid().getRows())
         if self.__config.muted:
@@ -408,15 +415,3 @@ class SimulationScreen:
             for entityName in set(entityNames):
                 print(entityName + ": " + str(entityNames.count(entityName)))
             print("")
-
-    # Prints some stuff to the screen and restarts the simulation. Utilizes initializeSimulation()
-    def __restartSimulation(self):
-        self.simulation.cleanup()
-        self.tickLengths.append(self.simulation.numTicks)
-        if self.__config.randomizeGridSizeUponRestart:
-            self.__config.randomizeGridSize()
-            self.__config.randomizeGrassGrowTime()
-            self.__config.calculateValues()
-        self.__initializeSimulation()
-        if self.__paused:
-            self.__paused = False


### PR DESCRIPTION
## Problem
There is no way for the user to customize the simulation in-game at the moment.

## Solution
A setup screen has been introduced allowing the user to select a grid size and grass factor for the simulation. Once the simulation is over, the user is returned to the setup screen.

## Relevant Issues
Closes #101 