### PR TITLE
Align simulation mechanics with RESEARCH.md

### DIFF
--- a/src/actionhandler/moveActionHandler.py
+++ b/src/actionhandler/moveActionHandler.py
@@ -24,24 +24,34 @@ class MoveActionHandler:
         elif direction == 3:
             return grid.getLeft(location)
         
-    def searchForFood(self, entity, grid: Grid, location: Location):
-        # search current location
+    def countEdibleEntities(self, entity, location: Location):
+        count = 0
         for eid in location.getEntities():
-            targetEntity = location.getEntities()[eid]
-            if entity.canEat(targetEntity):
-                return location
-        
-        # search nearby locations
+            if entity.canEat(location.getEntities()[eid]):
+                count += 1
+        return count
+
+    def searchForFood(self, entity, grid: Grid, location: Location):
+        # optimal foraging theory (RESEARCH.md): don't abandon a patch that already has food.
+        if self.countEdibleEntities(entity, location) > 0:
+            return location
+
+        # search nearby locations and prefer the richest patch found within the search budget,
+        # rather than settling for the first patch with any food at all.
+        bestLocation = -1
+        bestFoodCount = 0
         attempts = 0
-        while attempts < random.randrange(1, 5):
+        maxAttempts = random.randrange(1, 5)
+        while attempts < maxAttempts:
             searchLocation = self.chooseRandomDirection(grid, location)
+            attempts += 1
             if searchLocation == -1:
                 continue
-            for e in searchLocation.getEntities():
-                if entity.canEat(e):
-                    return searchLocation
-            attempts += 1
-        return -1
+            foodCount = self.countEdibleEntities(entity, searchLocation)
+            if foodCount > bestFoodCount:
+                bestFoodCount = foodCount
+                bestLocation = searchLocation
+        return bestLocation
     
     def isLocationImpassible(self, location: Location):
         # search current location

--- a/src/entity/chicken.py
+++ b/src/entity/chicken.py
@@ -8,4 +8,5 @@ from entity.livingEntity import LivingEntity
 # @since July 7th, 2022
 class Chicken(LivingEntity):
     def __init__(self, name):
-        LivingEntity.__init__(self, name, (random.randrange(245, 249), random.randrange(245, 249), random.randrange(245, 249)), False, random.randrange(20, 30), [Grass, Berries])
+        # r-selected: small-bodied prey species, high reproduction (RESEARCH.md, "r/K selection theory").
+        LivingEntity.__init__(self, name, (random.randrange(245, 249), random.randrange(245, 249), random.randrange(245, 249)), False, random.randrange(20, 30), [Grass, Berries], reproductiveRate=2.0)

--- a/src/entity/cow.py
+++ b/src/entity/cow.py
@@ -7,4 +7,5 @@ from entity.livingEntity import LivingEntity
 # @since July 31st, 2022
 class Cow(LivingEntity):
     def __init__(self, name):
-        LivingEntity.__init__(self, name, (random.randrange(59, 61), random.randrange(41, 45), random.randrange(29, 33)), False, random.randrange(40, 50), [Grass, Cow])
+        # Cows are herbivores and grazers, so their diet is limited to plant matter (see RESEARCH.md, "Trophic energy transfer"; fixes #113).
+        LivingEntity.__init__(self, name, (random.randrange(59, 61), random.randrange(41, 45), random.randrange(29, 33)), False, random.randrange(40, 50), [Grass], reproductiveRate=0.5)

--- a/src/entity/fox.py
+++ b/src/entity/fox.py
@@ -11,4 +11,5 @@ from entity.rabbit import Rabbit
 # @since August 2nd, 2022
 class Fox(LivingEntity):
     def __init__(self, name):
-        LivingEntity.__init__(self,name,(255, random.randrange(163, 167), 0), False, random.randrange(50, 100),[Chicken, Pig, Rabbit])
+        # Smaller mesopredator: more K-selected than its prey, less so than the apex predator (RESEARCH.md, "r/K selection theory").
+        LivingEntity.__init__(self,name,(255, random.randrange(163, 167), 0), False, random.randrange(50, 100),[Chicken, Pig, Rabbit], reproductiveRate=0.8)

--- a/src/entity/livingEntity.py
+++ b/src/entity/livingEntity.py
@@ -9,12 +9,17 @@ class LivingEntity(DrawableEntity):
     MALE = 0
     FEMALE = 1
     
-    def __init__(self, name, color, solid, energy, edibleEntityTypes):
+    def __init__(self, name, color, solid, energy, edibleEntityTypes, reproductiveRate=1.0):
         DrawableEntity.__init__(self, name, color, solid)
         self.energy = energy
         self.edibleEntityTypes = edibleEntityTypes
         self.targetEnergy = energy
         self.sex = random.choice([LivingEntity.MALE, LivingEntity.FEMALE])
+        # Multiplier on the base chance to reproduce, modeling where this species sits on the
+        # r/K selection spectrum (see RESEARCH.md, "r/K selection theory"): > 1.0 for r-selected
+        # species (many offspring, short investment), < 1.0 for K-selected species (few offspring,
+        # high investment per offspring).
+        self.reproductiveRate = reproductiveRate
     
     def getEnergy(self):
         return self.energy
@@ -36,3 +41,6 @@ class LivingEntity(DrawableEntity):
 
     def getSex(self):
         return self.sex
+
+    def getReproductiveRate(self):
+        return self.reproductiveRate

--- a/src/entity/pig.py
+++ b/src/entity/pig.py
@@ -9,4 +9,5 @@ from entity.livingEntity import LivingEntity
 # @since July 27th, 2022
 class Pig(LivingEntity):
     def __init__(self, name):
-        LivingEntity.__init__(self, name, (255, random.randrange(170, 190), random.randrange(180, 200)), False, random.randrange(30, 40), [Grass, Berries, BerryBush])
+        # Intermediate on the r/K spectrum: bigger litters than cattle but slower than rabbits (RESEARCH.md, "r/K selection theory").
+        LivingEntity.__init__(self, name, (255, random.randrange(170, 190), random.randrange(180, 200)), False, random.randrange(30, 40), [Grass, Berries, BerryBush], reproductiveRate=1.3)

--- a/src/entity/rabbit.py
+++ b/src/entity/rabbit.py
@@ -8,4 +8,5 @@ from entity.livingEntity import LivingEntity
 # @since August 2nd, 2022
 class Rabbit(LivingEntity):
     def __init__(self, name):
-        LivingEntity.__init__(self, name, (250,220,200), False, random.randrange(20, 30), [Grass, Berries])
+        # Textbook r-strategist: the highest reproduction rate in the ecosystem (RESEARCH.md, "r/K selection theory").
+        LivingEntity.__init__(self, name, (250,220,200), False, random.randrange(20, 30), [Grass, Berries], reproductiveRate=2.5)

--- a/src/entity/wolf.py
+++ b/src/entity/wolf.py
@@ -12,4 +12,5 @@ from entity.rabbit import Rabbit
 # @since July 27th, 2022
 class Wolf(LivingEntity):
     def __init__(self, name):
-        LivingEntity.__init__(self, name, (145, random.randrange(145, 155), random.randrange(145, 155)), False, random.randrange(100, 200), [Chicken, Pig, Cow, Fox, Rabbit])
+        # Apex predator: the most K-selected species, matching its larger energy pool and scarcer numbers (RESEARCH.md, "r/K selection theory" and "Trophic energy transfer").
+        LivingEntity.__init__(self, name, (145, random.randrange(145, 155), random.randrange(145, 155)), False, random.randrange(100, 200), [Chicken, Pig, Cow, Fox, Rabbit], reproductiveRate=0.4)

--- a/src/simulation/simulation.py
+++ b/src/simulation/simulation.py
@@ -301,7 +301,7 @@ class Simulation:
             else:
                 if self.shouldEntityExcrete():
                     self.__excreteActionHandler.initiateExcreteAction(entity, self.addEntityToTrackedEntities, self.numTicks)
-                if self.shouldEntityReproduce():
+                if self.shouldEntityReproduce(entity):
                     self.__reproduceActionHandler.initiateReproduceAction(entity, self.addEntityToTrackedEntities)
 
     def decreaseEnergyForLivingEntities(self):
@@ -311,14 +311,32 @@ class Simulation:
             if entity.getEnergy() <= 0:
                 self.removeEntity(entity)
                 
+    def isNearWater(self, location, grid):
+        neighboringLocations = [grid.getUp(location), grid.getRight(location), grid.getDown(location), grid.getLeft(location)]
+        for neighboringLocation in neighboringLocations:
+            if neighboringLocation == -1:
+                continue
+            for entityId in neighboringLocation.getEntities():
+                if type(neighboringLocation.getEntity(entityId)) is Water:
+                    return True
+        return False
+
     def shouldExcrementTurnIntoGrass(self, excrement):
-        return (self.numTicks - excrement.getTick()) > self.getConfig().grassGrowTime
+        grid = self.environment.getGrid()
+        location = grid.getLocation(excrement.getLocationID())
+        requiredGrowTime = self.getConfig().grassGrowTime
+        if self.isNearWater(location, grid):
+            # moisture speeds up decomposition of organic matter into nutrients (RESEARCH.md, "Detritus, decomposition, and nutrient cycling")
+            requiredGrowTime = requiredGrowTime // 2
+        return (self.numTicks - excrement.getTick()) > requiredGrowTime
 
     def shouldBerryBushGainEnergy(self):
         return random.randrange(0, 100) < 10
 
     def shouldEntityExcrete(self):
         return random.randrange(0, 100) < (self.getConfig().chanceToExcrete*100)
-    
-    def shouldEntityReproduce(self):
-        return random.randrange(0, 100) < (self.getConfig().chanceToReproduce*100)
+
+    def shouldEntityReproduce(self, entity):
+        # r/K selection theory (RESEARCH.md): each species' reproductive rate scales the shared base chance.
+        chance = min(self.getConfig().chanceToReproduce * entity.getReproductiveRate(), 1.0)
+        return random.randrange(0, 100) < (chance*100)

--- a/tests/actionhandler/test_moveActionHandler.py
+++ b/tests/actionhandler/test_moveActionHandler.py
@@ -1,0 +1,90 @@
+from unittest.mock import MagicMock, patch
+
+from actionhandler.moveActionHandler import MoveActionHandler
+from entity.grass import Grass
+from entity.rabbit import Rabbit
+from entity.water import Water
+from lib.pyenvlib.grid import Grid
+
+
+def getHandler():
+    return MoveActionHandler(MagicMock())
+
+def test_countEdibleEntities_countsOnlyEdibleEntities():
+    # prepare
+    handler = getHandler()
+    grid = Grid(3, 3)
+    location = grid.getLocationByCoordinates(1, 1)
+    rabbit = Rabbit("test rabbit")
+    location.addEntity(Grass())
+    location.addEntity(Grass())
+    location.addEntity(Water())  # not edible by a rabbit
+
+    # execute
+    result = handler.countEdibleEntities(rabbit, location)
+
+    # assert
+    assert result == 2
+
+def test_searchForFood_prefersCurrentLocationWhenFoodIsAlreadyPresent():
+    # prepare: this models the marginal value theorem (RESEARCH.md, "Optimal foraging theory") -
+    # an entity shouldn't abandon a patch that already has food to go searching for a better one.
+    handler = getHandler()
+    grid = Grid(3, 3)
+    location = grid.getLocationByCoordinates(1, 1)
+    rabbit = Rabbit("test rabbit")
+    location.addEntity(Grass())
+
+    richerNeighbor = grid.getLocationByCoordinates(1, 0)
+    richerNeighbor.addEntity(Grass())
+    richerNeighbor.addEntity(Grass())
+    richerNeighbor.addEntity(Grass())
+
+    # execute
+    result = handler.searchForFood(rabbit, grid, location)
+
+    # assert
+    assert result == location
+
+@patch("actionhandler.moveActionHandler.random")
+def test_searchForFood_prefersTheRichestNeighboringPatch(mock_random):
+    # prepare: no food in the current location; two neighboring patches have food,
+    # one richer than the other. Optimal foraging theory predicts a preference for
+    # the denser patch (RESEARCH.md, "Optimal foraging theory").
+    handler = getHandler()
+    grid = Grid(3, 3)
+    location = grid.getLocationByCoordinates(1, 1)
+    rabbit = Rabbit("test rabbit")
+
+    up = grid.getLocationByCoordinates(1, 0)      # direction 0
+    right = grid.getLocationByCoordinates(2, 1)   # direction 1
+    down = grid.getLocationByCoordinates(1, 2)    # direction 2
+    left = grid.getLocationByCoordinates(0, 1)    # direction 3
+
+    up.addEntity(Grass())
+    down.addEntity(Grass())
+    down.addEntity(Grass())
+    down.addEntity(Grass())
+
+    # first randrange call picks maxAttempts (visit all 4 directions),
+    # remaining calls pick the direction for each attempt: up, right, down, left
+    mock_random.randrange.side_effect = [4, 0, 1, 2, 3]
+
+    # execute
+    result = handler.searchForFood(rabbit, grid, location)
+
+    # assert
+    assert result == down
+
+def test_searchForFood_returnsNegativeOneWhenNoFoodIsFound():
+    # prepare
+    handler = getHandler()
+    grid = Grid(3, 3)
+    location = grid.getLocationByCoordinates(1, 1)
+    rabbit = Rabbit("test rabbit")
+
+    # execute
+    result = handler.searchForFood(rabbit, grid, location)
+
+    # assert
+    assert result == -1

--- a/tests/entity/test_livingEntity.py
+++ b/tests/entity/test_livingEntity.py
@@ -1,0 +1,34 @@
+from entity.chicken import Chicken
+from entity.cow import Cow
+from entity.fox import Fox
+from entity.grass import Grass
+from entity.pig import Pig
+from entity.rabbit import Rabbit
+from entity.wolf import Wolf
+
+
+def test_cow_cannotEatOtherCows():
+    # a herbivore shouldn't be able to prey on its own trophic level (RESEARCH.md,
+    # "Trophic energy transfer"; fixes #113)
+    cow = Cow("test cow")
+    otherCow = Cow("other cow")
+
+    assert cow.canEat(otherCow) == False
+    assert cow.canEat(Grass()) == True
+
+def test_reproductiveRate_defaultsToNeutral():
+    cow = Cow("test cow")
+    assert cow.getReproductiveRate() == 0.5
+
+def test_reproductiveRate_rSelectedSpeciesAreHigherThanKSelectedSpecies():
+    # r/K selection theory (RESEARCH.md): small prey with short lifespans should have a
+    # higher reproductive rate than large, long-lived apex predators.
+    rabbit = Rabbit("test rabbit")
+    chicken = Chicken("test chicken")
+    pig = Pig("test pig")
+    fox = Fox("test fox")
+    cow = Cow("test cow")
+    wolf = Wolf("test wolf")
+
+    assert rabbit.getReproductiveRate() > chicken.getReproductiveRate() > pig.getReproductiveRate()
+    assert pig.getReproductiveRate() > fox.getReproductiveRate() > cow.getReproductiveRate() > wolf.getReproductiveRate()

--- a/tests/simulation/test_simulation.py
+++ b/tests/simulation/test_simulation.py
@@ -5,6 +5,8 @@ from entity.berryBush import BerryBush
 from entity.chicken import Chicken
 from entity.excrement import Excrement
 from entity.grass import Grass
+from entity.water import Water
+from lib.pyenvlib.grid import Grid
 from lib.pyenvlib.location import Location
 import service
 from src.simulation import simulation
@@ -757,28 +759,98 @@ def test_decreaseEnergyForLivingEntities_OutOfEnergy():
 def test_shouldExcrementTurnIntoGrass_False():
     # prepare
     testSim = getTestSimulation()
+    grid = Grid(3, 3)
+    testSim.environment.setGrid(grid)
+    location = grid.getLocationByCoordinates(1, 1)
+    excrement = Excrement(1)
+    location.addEntity(excrement)
     testSim.getConfig().grassGrowTime = 2
     testSim.numTicks = 1
-    excrement = Excrement(1)
-    
+
     # execute
     result = testSim.shouldExcrementTurnIntoGrass(excrement)
-    
+
     # assert
     assert result == False
-    
+
 def test_shouldExcrementTurnIntoGrass_True():
     # prepare
     testSim = getTestSimulation()
+    grid = Grid(3, 3)
+    testSim.environment.setGrid(grid)
+    location = grid.getLocationByCoordinates(1, 1)
+    excrement = Excrement(7)
+    location.addEntity(excrement)
     testSim.getConfig().grassGrowTime = 2
     testSim.numTicks = 10
-    excrement = Excrement(7)
-    
+
     # execute
     result = testSim.shouldExcrementTurnIntoGrass(excrement)
-    
+
     # assert
     assert result == True
+
+def test_shouldExcrementTurnIntoGrass_NearWater_AcceleratesDecomposition():
+    # prepare
+    testSim = getTestSimulation()
+    grid = Grid(3, 3)
+    testSim.environment.setGrid(grid)
+    location = grid.getLocationByCoordinates(1, 1)
+    waterLocation = grid.getLocationByCoordinates(1, 0)
+    waterLocation.addEntity(Water())
+    excrement = Excrement(1)
+    location.addEntity(excrement)
+    testSim.getConfig().grassGrowTime = 10
+    testSim.numTicks = 7
+
+    # execute
+    result = testSim.shouldExcrementTurnIntoGrass(excrement)
+
+    # assert (age of 6 wouldn't clear a grow time of 10, but does clear the halved 5)
+    assert result == True
+
+def test_shouldExcrementTurnIntoGrass_FarFromWater_DoesNotAccelerateDecomposition():
+    # prepare
+    testSim = getTestSimulation()
+    grid = Grid(3, 3)
+    testSim.environment.setGrid(grid)
+    location = grid.getLocationByCoordinates(1, 1)
+    excrement = Excrement(1)
+    location.addEntity(excrement)
+    testSim.getConfig().grassGrowTime = 10
+    testSim.numTicks = 7
+
+    # execute
+    result = testSim.shouldExcrementTurnIntoGrass(excrement)
+
+    # assert (age of 6 does not clear a grow time of 10 when there's no water nearby)
+    assert result == False
+
+def test_isNearWater_True():
+    # prepare
+    testSim = getTestSimulation()
+    grid = Grid(3, 3)
+    location = grid.getLocationByCoordinates(1, 1)
+    waterLocation = grid.getLocationByCoordinates(1, 0)
+    waterLocation.addEntity(Water())
+
+    # execute
+    result = testSim.isNearWater(location, grid)
+
+    # assert
+    assert result == True
+
+def test_isNearWater_False():
+    # prepare
+    testSim = getTestSimulation()
+    grid = Grid(3, 3)
+    location = grid.getLocationByCoordinates(1, 1)
+
+    # execute
+    result = testSim.isNearWater(location, grid)
+
+    # assert
+    assert result == False
 
 @patch("src.simulation.simulation.random")
 def test_shouldBerryBushGainEnergy_True(mock_random):
@@ -836,10 +908,12 @@ def test_shouldEntityReproduce_True(mock_random):
     testSim = getTestSimulation()
     mock_random.randrange.return_value = 5
     testSim.getConfig().chanceToReproduce = 0.10
-    
+    entity = MagicMock()
+    entity.getReproductiveRate.return_value = 1.0
+
     # execute
-    result = testSim.shouldEntityReproduce()
-    
+    result = testSim.shouldEntityReproduce(entity)
+
     # assert
     assert result == True
 
@@ -849,9 +923,44 @@ def test_shouldEntityReproduce_False(mock_random):
     testSim = getTestSimulation()
     mock_random.randrange.return_value = 50
     testSim.getConfig().chanceToReproduce = 0.10
-    
+    entity = MagicMock()
+    entity.getReproductiveRate.return_value = 1.0
+
     # execute
-    result = testSim.shouldEntityReproduce()
-    
+    result = testSim.shouldEntityReproduce(entity)
+
     # assert
     assert result == False
+
+@patch("src.simulation.simulation.random")
+def test_shouldEntityReproduce_ScalesWithReproductiveRate(mock_random):
+    # prepare: base chance alone (10%) wouldn't beat a roll of 15, but an r-selected
+    # species with a 2x reproductive rate (20%) should.
+    testSim = getTestSimulation()
+    mock_random.randrange.return_value = 15
+    testSim.getConfig().chanceToReproduce = 0.10
+    entity = MagicMock()
+    entity.getReproductiveRate.return_value = 2.0
+
+    # execute
+    result = testSim.shouldEntityReproduce(entity)
+
+    # assert
+    assert result == True
+
+@patch("src.simulation.simulation.random")
+def test_shouldEntityReproduce_ChanceIsCappedAt100Percent(mock_random):
+    # prepare: base chance (60%) times reproductive rate (2.0) would be 120% uncapped;
+    # it should be clamped to 100% rather than always succeeding by more than that.
+    testSim = getTestSimulation()
+    mock_random.randrange.return_value = 99
+    testSim.getConfig().chanceToReproduce = 0.60
+    entity = MagicMock()
+    entity.getReproductiveRate.return_value = 2.0
+
+    # execute
+    result = testSim.shouldEntityReproduce(entity)
+
+    # assert
+    assert result == True
+    mock_random.randrange.assert_called_once_with(0, 100)


### PR DESCRIPTION
Stacked on #118 (adds `RESEARCH.md`). This PR is the first pass at actually using it: four mechanic changes, each traced to a specific section of the doc, plus tests.

## Changes

- **Cows no longer eat other cows** (`src/entity/cow.py`) — herbivores shouldn't prey on their own trophic level (§"Trophic energy transfer"). Also fixes #113.
- **Per-species reproduction rates via r/K selection** (`src/entity/livingEntity.py` + all six species files, `src/simulation/simulation.py`) — `chanceToReproduce` used to be one global constant for every species. Each `LivingEntity` now carries a `reproductiveRate` multiplier: r-selected prey (Rabbit 2.5x, Chicken 2.0x) reproduce much faster than K-selected predators (Fox 0.8x, Cow 0.5x, Wolf 0.4x), per §"r/K selection theory". `shouldEntityReproduce` scales and caps the chance at 100%.
- **Patch-preferring foraging** (`src/actionhandler/moveActionHandler.py`) — `searchForFood` used to move to the *first* nearby location with any food. It now never abandons a patch that already has food, and among unexplored neighbors prefers the richest one it finds within its search budget, per §"Optimal foraging theory" (marginal value theorem).
- **Moisture-accelerated decomposition** (`src/simulation/simulation.py`, new `isNearWater`) — excrement near water turns into grass in half the normal `grassGrowTime`, per §"Detritus, decomposition, and nutrient cycling". This addresses #67 ("only turn into grass near water") but deliberately accelerates rather than gates the mechanic: an outright water requirement risks starving grass regrowth across sparsely-watered maps (water tiles are `gridSize * waterFactor`, far sparser than grass tiles), which is exactly the kind of change §"Predator-prey population dynamics" warns can tip a stable food web into collapse.

## Tests

- Updated `tests/simulation/test_simulation.py` for the `shouldEntityReproduce`/`shouldExcrementTurnIntoGrass` signature changes, plus new cases for reproductive-rate scaling, the 100%-cap, and water-adjacent decomposition.
- Added `tests/actionhandler/test_moveActionHandler.py` and `tests/entity/test_livingEntity.py` — action handlers and entities had zero test coverage before this (#117); these cover the new/changed behavior specifically, not full coverage of those modules.

## Test plan
- [x] `python3 -m pytest tests -q` — 63 passed (was 50 before this PR).
- [x] Manual 1000-tick smoke run with real (non-mocked) `Config`/`Simulation`/pygame objects (headless, dummy SDL drivers) — completes without errors, ecosystem survives with a mixed population.
- [x] Confirmed `Cow("player-created-cow")` call site in `simulationScreen.py` (player-created cow) still works unchanged — new constructor params are optional with defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)